### PR TITLE
Add vs-code marketplace link to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Open Collaboration Server
 
 This repository host implementations of the open collaboration protocol.
+
+## Open Collaboration Tools Extension
+
+[![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/typefox.open-collaboration-tools?label=VS-Code%20Marketplace)](https://marketplace.visualstudio.com/items?itemName=typefox.open-collaboration-tools)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3047,10 +3047,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/oct-live-collaboration": {
-      "resolved": "packages/open-collaboration-vscode",
-      "link": true
-    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "license": "MIT",
@@ -3093,6 +3089,10 @@
     },
     "node_modules/open-collaboration-server": {
       "resolved": "packages/open-collaboration-server",
+      "link": true
+    },
+    "node_modules/open-collaboration-tools": {
+      "resolved": "packages/open-collaboration-vscode",
       "link": true
     },
     "node_modules/open-collaboration-yjs": {
@@ -4859,7 +4859,7 @@
       }
     },
     "packages/open-collaboration-vscode": {
-      "name": "oct-live-collaboration",
+      "name": "open-collaboration-tools",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Small marketplace badge that shows current extension version and linkt to the extension's marketplace site.


<img width="560" alt="Bildschirmfoto 2024-06-19 um 10 36 32" src="https://github.com/TypeFox/open-collaboration-tools/assets/454322/9eeb6853-4dca-4db2-b3e6-30ab3cea34d8">
