### PR TITLE
Prevent sharing notebook cells

### DIFF
--- a/packages/open-collaboration-vscode/src/collaboration-instance.ts
+++ b/packages/open-collaboration-vscode/src/collaboration-instance.ts
@@ -361,15 +361,21 @@ export class CollaborationInstance implements vscode.Disposable {
     private registerEditorEvents() {
 
         vscode.workspace.textDocuments.forEach(document => {
-            this.registerTextDocument(document);
+            if (!this.isNotebookCell(document)) {
+                this.registerTextDocument(document);
+            }
         });
 
         this.toDispose.push(vscode.workspace.onDidOpenTextDocument(document => {
-            this.registerTextDocument(document);
+            if (!this.isNotebookCell(document)) {
+                this.registerTextDocument(document);
+            }
         }));
 
         this.toDispose.push(vscode.workspace.onDidChangeTextDocument(event => {
-            this.updateTextDocument(event);
+            if (!this.isNotebookCell(event.document)) {
+                this.updateTextDocument(event);
+            }
         }));
 
         this.toDispose.push(vscode.window.onDidChangeVisibleTextEditors(() => {
@@ -400,6 +406,10 @@ export class CollaborationInstance implements vscode.Disposable {
                 awarenessDebounce();
             }
         });
+    }
+
+    protected isNotebookCell(doc: vscode.TextDocument): boolean {
+        return doc.uri.scheme === 'vscode-notebook-cell';
     }
 
     followUser(id?: string) {


### PR DESCRIPTION
When opening a notebook with the current version of the vscode extension, data across notebook cells is lost due to the way how notebook cell URIs are structured.

Until we have actual support for notebooks, we should just ignore all notebook cell documents.