### PR TITLE
Enable reconnection

### DIFF
--- a/packages/open-collaboration-protocol/src/messages.ts
+++ b/packages/open-collaboration-protocol/src/messages.ts
@@ -18,6 +18,7 @@ export namespace Messages {
     export namespace Room {
         export const Joined = new BroadcastType<[types.Peer]>('room/joined');
         export const Left = new BroadcastType<[types.Peer]>('room/left');
+        export const Leave = new NotificationType<[]>('room/leave');
         export const PermissionsUpdated = new BroadcastType<[types.Permissions]>('room/permissionsUpdated');
         export const Closed = new BroadcastType('room/closed');
     }

--- a/packages/open-collaboration-protocol/src/transport/socket-io-transport.ts
+++ b/packages/open-collaboration-protocol/src/transport/socket-io-transport.ts
@@ -45,7 +45,10 @@ export class SocketIoTransport implements MessageTransport {
         this.socket.on('disconnect', (_reason, _description) => {
             this.ready = new Deferred();
             // Give it 30 seconds to reconnect before firing the disconnect event
-            this.disconnectTimeout = setTimeout(() => this.onDisconnectEmitter.fire(), 30_000);
+            this.disconnectTimeout = setTimeout(() => {
+                this.onDisconnectEmitter.fire();
+                this.disconnectTimeout = undefined;
+            }, 30_000);
         });
         this.socket.io.on('reconnect', () => {
             if (this.disconnectTimeout) {

--- a/packages/open-collaboration-protocol/src/transport/transport.ts
+++ b/packages/open-collaboration-protocol/src/transport/transport.ts
@@ -6,7 +6,7 @@
 
 import { Event } from '../utils/event';
 
-export type ConnectionWriter = (data: ArrayBuffer) => void;
+export type ConnectionWriter = (data: ArrayBuffer) => Promise<void>;
 export type ConnectionReader = (cb: (data: ArrayBuffer) => void) => void;
 
 export interface MessageTransportProvider {
@@ -19,6 +19,7 @@ export interface MessageTransport {
     write: ConnectionWriter;
     read: ConnectionReader;
     dispose(): void;
+    onReconnect: Event<void>;
     onDisconnect: Event<void>;
     onError: Event<string>;
 }

--- a/packages/open-collaboration-protocol/src/transport/websocket-transport.ts
+++ b/packages/open-collaboration-protocol/src/transport/websocket-transport.ts
@@ -39,6 +39,10 @@ export class WebSocketTransport implements MessageTransport {
     private onErrorEmitter = new Emitter<string>();
     private ready = new Deferred();
 
+    get onReconnect(): Event<void> {
+        return Event.None;
+    }
+
     get onDisconnect(): Event<void> {
         return this.onDisconnectEmitter.event;
     }
@@ -53,8 +57,8 @@ export class WebSocketTransport implements MessageTransport {
         this.socket.onopen = () => this.ready.resolve();
     }
 
-    write(data: ArrayBuffer): void {
-        this.ready.promise.then(() => this.socket.send(data));
+    async write(data: ArrayBuffer): Promise<void> {
+        await this.ready.promise.then(() => this.socket.send(data));
     }
 
     read(cb: (data: ArrayBuffer) => void): void {

--- a/packages/open-collaboration-server/src/channel.ts
+++ b/packages/open-collaboration-server/src/channel.ts
@@ -6,16 +6,109 @@
 
 import { Socket } from 'socket.io';
 import * as ws from 'ws';
-import { Disposable, Emitter, Encoding, BinaryMessage, Event } from 'open-collaboration-protocol';
+import { Disposable, Emitter, Encoding, BinaryMessage, Event, DisposableCollection } from 'open-collaboration-protocol';
 
-export interface Channel {
+export class Channel {
+
+    private onDidCloseEmitter = new Emitter<void>();
+    private onDidDisconnectEmitter = new Emitter<void>();
+    private onDidReconnectEmitter = new Emitter<void>();
+    private onMessageEmitter = new Emitter<BinaryMessage>();
+
+    get onClose(): Event<void> {
+        return this.onDidCloseEmitter.event;
+    }
+
+    get onDisconnect(): Event<void> {
+        return this.onDidDisconnectEmitter.event;
+    }
+
+    get onReconnect(): Event<void> {
+        return this.onDidReconnectEmitter.event;
+    }
+
+    get transport(): TransportChannel | undefined {
+        return this._transport;
+    }
+
+    set transport(transport: TransportChannel | undefined) {
+        this.toDispose.dispose();
+        this._transport = transport;
+        if (transport) {
+            this.toDispose.push(transport.onClose(() => {
+                this.onDidDisconnectEmitter.fire();
+                this._transport = undefined;
+            }));
+            this.toDispose.push(transport.onMessage(message => {
+                this.onMessageEmitter.fire(message);
+            }));
+            this.onDidReconnectEmitter.fire();
+            for (const message of this.buffer) {
+                transport.sendMessage(message);
+            }
+            this.buffer = [];
+        }
+    }
+
+    private _transport?: TransportChannel;
+    // Buffer to store messages that couldn't be sent yet due to a disconnect
+    private buffer: BinaryMessage[] = [];
+    private toDispose = new DisposableCollection();
+    private closeTimeout: NodeJS.Timeout | undefined;
+
+    constructor(transport: TransportChannel) {
+        this._transport = transport;
+        this.toDispose.push(transport.onClose(() => {
+            this.onDidDisconnectEmitter.fire();
+            this._transport = undefined;
+        }));
+        this.toDispose.push(transport.onMessage(message => {
+            this.onMessageEmitter.fire(message);
+        }));
+        this.onDisconnect(() => {
+            this.closeTimeout = setTimeout(() => {
+                this.close();
+            }, 30_000);
+        });
+        this.onReconnect(() => {
+            if (this.closeTimeout) {
+                clearTimeout(this.closeTimeout);
+                this.closeTimeout = undefined;
+            }
+        });
+    }
+
+    get onMessage(): Event<BinaryMessage> {
+        return this.onMessageEmitter.event;
+    }
+
+    sendMessage(message: BinaryMessage): void {
+        if (this._transport) {
+            this._transport.sendMessage(message);
+        } else {
+            this.buffer.push(message);
+        }
+    }
+
+    close(): void {
+        this.toDispose.dispose();
+        this.onDidCloseEmitter.fire();
+        this.onDidCloseEmitter.dispose();
+        this.onDidDisconnectEmitter.dispose();
+        this.onDidReconnectEmitter.dispose();
+        this.transport?.close();
+    }
+
+}
+
+export interface TransportChannel {
     onMessage(cb: (message: BinaryMessage) => void): Disposable;
     sendMessage(message: BinaryMessage): void;
     close(): void;
     onClose: Event<void>;
 }
 
-export class WebSocketChannel implements Channel {
+export class WebSocketChannel implements TransportChannel {
     private onDidCloseEmitter = new Emitter<void>();
 
     get onClose(): Event<void> {
@@ -54,7 +147,7 @@ export class WebSocketChannel implements Channel {
 
 }
 
-export class SocketIoChannel implements Channel {
+export class SocketIoChannel implements TransportChannel {
 
     private onDidCloseEmitter = new Emitter<void>();
 

--- a/packages/open-collaboration-server/src/container.ts
+++ b/packages/open-collaboration-server/src/container.ts
@@ -17,6 +17,7 @@ import { SimpleLoginEndpoint } from './auth-endpoints/simple-login-endpoint';
 import { AuthEndpoint } from './auth-endpoints/auth-endpoint';
 import { GitHubOAuthEndpoint, GoogleOAuthEndpoint  } from './auth-endpoints/oauth-endpoint';
 import { Configuration, DefaultConfiguration } from './utils/configuration';
+import { PeerManager } from './peer-manager';
 
 export default new ContainerModule(bind => {
     bind(LoggerSymbol).to(ConsoleLogger).inSingletonScope();
@@ -35,6 +36,7 @@ export default new ContainerModule(bind => {
         child.bind(PeerInfo).toConstantValue(peerInfo);
         return child.get(PeerImpl);
     });
+    bind(PeerManager).toSelf().inSingletonScope();
 
     bind(SimpleLoginEndpoint).toSelf().inSingletonScope();
     bind(AuthEndpoint).toService(SimpleLoginEndpoint);

--- a/packages/open-collaboration-server/src/message-relay.ts
+++ b/packages/open-collaboration-server/src/message-relay.ts
@@ -40,7 +40,7 @@ export class MessageRelay {
             clearTimeout(timeout);
             deferred.reject(new Error('Request timed out'));
         };
-        const timeout = setTimeout(dispose, 300_000);
+        const timeout = setTimeout(dispose, 30_000);
         this.requestMap.set(key, {
             id: messageId,
             response: deferred,

--- a/packages/open-collaboration-server/src/peer-manager.ts
+++ b/packages/open-collaboration-server/src/peer-manager.ts
@@ -1,0 +1,24 @@
+// ******************************************************************************
+// Copyright 2024 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+// ******************************************************************************
+
+import { injectable } from "inversify";
+import { Peer } from "./types";
+
+@injectable()
+export class PeerManager {
+    
+    private readonly peers: Map<string, Peer> = new Map();
+
+    register(peer: Peer): void {
+        this.peers.set(peer.jwt, peer);
+        peer.onDispose(() => this.peers.delete(peer.jwt));
+    }
+
+    getPeer(jwt: string): Peer | undefined {
+        return this.peers.get(jwt);
+    }
+
+}

--- a/packages/open-collaboration-server/src/types.ts
+++ b/packages/open-collaboration-server/src/types.ts
@@ -4,10 +4,13 @@
 // terms of the MIT License, which is available in the project root.
 // ******************************************************************************
 
-import { Channel } from './channel';
+import { Channel, TransportChannel } from './channel';
 import * as protocol from 'open-collaboration-protocol';
 
 export class Room {
+
+    clock = 0;
+
     constructor(public id: string, public host: Peer, public guests: Peer[]) {
     }
 
@@ -38,21 +41,24 @@ export function isUser(obj: unknown): obj is User {
 export const PeerInfo = Symbol('PeerInfo');
 
 export interface PeerInfo {
+    jwt: string;
     user: User;
     host: boolean;
+    channel: TransportChannel;
     client: string;
     publicKey: string;
     supportedCompression: string[];
-    channel: Channel;
 }
 
-export interface Peer {
+export interface Peer extends protocol.Disposable {
+    jwt: string;
     id: string;
     client: string;
     host: boolean;
     user: User;
     channel: Channel;
     room: Room;
+    onDispose: protocol.Event<void>;
     toProtocol(): protocol.Peer
     toEncryptionKey(): protocol.Encryption.AsymmetricKey
 }

--- a/packages/open-collaboration-vscode/src/commands.ts
+++ b/packages/open-collaboration-vscode/src/commands.ts
@@ -88,6 +88,7 @@ export class Commands {
             vscode.commands.registerCommand('oct.closeConnection', async () => {
                 const instance = CollaborationInstance.Current;
                 if (instance) {
+                    await instance.leave();
                     instance.dispose();
                     this.contextKeyService.setConnection(undefined);
                     if (!instance.host) {

--- a/packages/open-collaboration-vscode/src/extension.ts
+++ b/packages/open-collaboration-vscode/src/extension.ts
@@ -21,6 +21,7 @@ export async function activate(context: vscode.ExtensionContext) {
 }
 
 export async function deactivate(): Promise<void> {
+    await CollaborationInstance.Current?.leave();
     CollaborationInstance.Current?.dispose();
     await closeSharedEditors();
     removeWorkspaceFolders();


### PR DESCRIPTION
Changes a few things to allow reconnection upon connection loss:
1. If a user disconnects from the server, they are not immediately removed from the room (unless they send the `room/leave` notification beforehand). Instead, the peer is kept alive for 30 seconds, during which the user can attempt to reconnect. For this reconnect, they need to use the exact same JWT, as they first used - otherwise they get treated as a new user.
2. All requests and notifications to that user will be buffered and resubmitted upon reconnection.
3. If the user loses connection, the client session won't be immediately disposed. Instead, the client will attempt to reconnect. If this happens within 30 seconds, the session will be continued as normal. The user might need to resync to any changes that happened in the meantime. `open-collaboration-yjs` takes care of this.