### PR TITLE
Fix editor desyncing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1063,6 +1063,14 @@
         "node": "*"
       }
     },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "dev": true,
@@ -4032,7 +4040,6 @@
     },
     "node_modules/tslib": {
       "version": "2.6.2",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {
@@ -4613,6 +4620,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "async-mutex": "^0.5.0",
         "inversify": "^6.0.2",
         "lodash.debounce": "^4.0.8",
         "node-fetch": "^2.0.0",

--- a/packages/open-collaboration-vscode/package.json
+++ b/packages/open-collaboration-vscode/package.json
@@ -166,6 +166,7 @@
     "check-types": "tsc --noEmit"
   },
   "dependencies": {
+    "async-mutex": "^0.5.0",
     "inversify": "^6.0.2",
     "reflect-metadata": "^0.2.2",
     "open-collaboration-yjs": "0.1.0",

--- a/packages/open-collaboration-vscode/package.json
+++ b/packages/open-collaboration-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "open-collaboration-tools",
   "displayName": "Open Collaboration Tools",
   "description": "Connect with others and live-share your code in real-time collaboration sessions",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publisher": "typefox",
   "categories": [
     "Other"

--- a/packages/open-collaboration-vscode/src/collaboration-instance.ts
+++ b/packages/open-collaboration-vscode/src/collaboration-instance.ts
@@ -399,6 +399,7 @@ export class CollaborationInstance implements vscode.Disposable {
         }));
 
         this.toDispose.push(vscode.window.onDidChangeVisibleTextEditors(() => {
+            this.updateTextSelection(vscode.window.activeTextEditor);
             this.rerenderPresence();
         }));
 
@@ -469,7 +470,11 @@ export class CollaborationInstance implements vscode.Disposable {
         }
     }
 
-    protected updateTextSelection(editor: vscode.TextEditor): void {
+    protected updateTextSelection(editor?: vscode.TextEditor): void {
+        if (!editor) {
+            this.setSharedSelection(undefined);
+            return;
+        }
         const uri = editor.document.uri;
         const path = this.getProtocolPath(uri);
         if (path) {
@@ -503,6 +508,8 @@ export class CollaborationInstance implements vscode.Disposable {
                 }))
             };
             this.setSharedSelection(textSelection);
+        } else {
+            this.setSharedSelection(undefined);
         }
     }
 
@@ -624,6 +631,12 @@ export class CollaborationInstance implements vscode.Disposable {
         const nameTagVisible = peer.lastUpdated !== undefined && Date.now() - peer.lastUpdated < 1900;
         const { path, textSelections } = selection;
         const uri = this.getResourceUri(path);
+        for (const visibleEditor of vscode.window.visibleTextEditors) {
+            visibleEditor.setDecorations(peer.decoration.before, []);
+            visibleEditor.setDecorations(peer.decoration.after, []);
+            visibleEditor.setDecorations(peer.decoration.nameTags.default, []);
+            visibleEditor.setDecorations(peer.decoration.nameTags.inverted, []);
+        }
         if (uri) {
             const editors = vscode.window.visibleTextEditors.filter(e => e.document.uri.toString() === uri.toString());
             if (editors.length > 0) {


### PR DESCRIPTION
Closes https://github.com/TypeFox/open-collaboration-tools/issues/37

There were two main culprits:
1. We used an incorrect, non-async mutex. This usually wasn't an issue on local networks due to low latency, but it leads to issues in production.
2. Ignore local Yjs events; After fixing the mutex situation, the editor continued acting up by adding every keypress twice to the document. This is fixed by simply ignoring all document changes that originate from the local client.