### PR TITLE
Always keep session member view up-to-date

### DIFF
--- a/packages/open-collaboration-vscode/src/collaboration-connection-provider.ts
+++ b/packages/open-collaboration-vscode/src/collaboration-connection-provider.ts
@@ -3,6 +3,7 @@ import { inject, injectable } from "inversify";
 import { ConnectionProvider, SocketIoTransportProvider } from 'open-collaboration-protocol'
 import fetch from 'node-fetch';
 import { ExtensionContext } from './inversify';
+import { packageVersion } from './utils/package';
 
 export const OCT_USER_TOKEN = 'oct.userToken';
 
@@ -13,19 +14,13 @@ export class CollaborationConnectionProvider {
     private context: vscode.ExtensionContext;
 
     async createConnection(userToken?: string): Promise<ConnectionProvider | undefined> {
-        let version = 'unknown';
-        try {
-            version = require('../package.json').version;
-        } catch (error) {
-            console.error('Failed to get the extension version', error);
-        }
         const serverUrl = vscode.workspace.getConfiguration().get<string>('oct.serverUrl');
         userToken ??= await this.context.secrets.get(OCT_USER_TOKEN);
 
         if (serverUrl) {
             return new ConnectionProvider({
                 url: serverUrl,
-                client: 'OCT-VSCode@' + version,
+                client: 'OCT-VSCode@' + packageVersion,
                 opener: (url) => vscode.env.openExternal(vscode.Uri.parse(url)),
                 transports: [SocketIoTransportProvider],
                 userToken,

--- a/packages/open-collaboration-vscode/src/collaboration-instance.ts
+++ b/packages/open-collaboration-vscode/src/collaboration-instance.ts
@@ -10,6 +10,11 @@ import { createMutex } from 'lib0/mutex';
 import debounce from 'lodash/debounce';
 import { inject, injectable, postConstruct } from "inversify";
 import { removeWorkspaceFolders } from "./utils/workspace";
+import { userColors } from "./utils/package";
+
+export interface PeerWithColor extends types.Peer {
+    color?: [number, number, number] | string;
+}
 
 export class DisposablePeer implements vscode.Disposable {
 
@@ -104,12 +109,7 @@ export class DisposablePeer implements vscode.Disposable {
 
 let colorIndex = 0;
 const defaultColors: ([number, number, number] | string)[] = [
-    'oct.user.yellow', // Yellow 
-    'oct.user.green', // Green
-    'oct.user.magenta', // Magenta
-    'oct.user.lightGreen', // Light green
-    'oct.user.lightOrange', // Light orange
-    'oct.user.lightMagenta', // Light magenta
+    ...userColors,
     [92, 45, 145], // Purple
     [0, 178, 148], // Light teal
     [255, 241, 0], // Light yellow
@@ -197,8 +197,15 @@ export class CollaborationInstance implements vscode.Disposable {
     private readonly onDidDisposeEmitter: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
     readonly onDidDispose: vscode.Event<void> = this.onDidDisposeEmitter.event;
 
-    get connectedUsers(): DisposablePeer[] {
-        return Array.from(this.peers.values());
+    get connectedUsers(): Promise<PeerWithColor[]> {
+        return this.ownUserData.then(own => {
+            const all = Array.from(this.peers.values()).map(e => ({
+                ...e.peer,
+                color: e.decoration.color
+            }) as PeerWithColor);
+            all.push(own);
+            return Array.from(all);
+        });
     }
 
     get ownUserData(): Promise<types.Peer> {
@@ -266,7 +273,6 @@ export class CollaborationInstance implements vscode.Disposable {
             await this.initialize(initData);
         });
         connection.room.onJoin(async (_, peer) => {
-            this.peers.set(peer.id, new DisposablePeer(this.yjsAwareness, peer));
             if (this.host) {
                 // Only initialize the user if we are the host
                 const roots = vscode.workspace.workspaceFolders ?? [];
@@ -283,6 +289,7 @@ export class CollaborationInstance implements vscode.Disposable {
                 };
                 connection.peer.init(peer.id, initData);
             }
+            this.peers.set(peer.id, new DisposablePeer(this.yjsAwareness, peer));
             this.onDidUsersChangeEmitter.fire();
         });
         connection.room.onLeave(async (_, peer) => {
@@ -304,6 +311,7 @@ export class CollaborationInstance implements vscode.Disposable {
         connection.peer.onInfo((_, peer) => {
             this.yjsAwareness.setLocalStateField('peer', peer.id);
             this.identity.resolve(peer);
+            this.onDidUsersChangeEmitter.fire();
         });
         connection.fs.onStat(async (_, path) => {
             const uri = this.getResourceUri(path);
@@ -696,6 +704,7 @@ export class CollaborationInstance implements vscode.Disposable {
             this.peers.set(peer.id, new DisposablePeer(this.yjsAwareness, peer));
         }
         this.toDispose.push(vscode.workspace.registerFileSystemProvider('oct', new CollaborationFileSystemProvider(this.options.connection, this.yjs, data.host)));
+        this.onDidUsersChangeEmitter.fire();
     }
 
     getProtocolPath(uri?: vscode.Uri): string | undefined {

--- a/packages/open-collaboration-vscode/src/collaboration-status-view.ts
+++ b/packages/open-collaboration-vscode/src/collaboration-status-view.ts
@@ -1,11 +1,11 @@
 import * as vscode from 'vscode';
-import { CollaborationInstance, DisposablePeer } from './collaboration-instance';
+import { CollaborationInstance, PeerWithColor } from './collaboration-instance';
 import { injectable } from 'inversify';
 
 @injectable()
-export class CollaborationStatusViewDataProvider implements vscode.TreeDataProvider<DisposablePeer> {
+export class CollaborationStatusViewDataProvider implements vscode.TreeDataProvider<PeerWithColor> {
 
-    private onDidChangeTreeDataEmitter = new vscode.EventEmitter<DisposablePeer[] | undefined>();
+    private onDidChangeTreeDataEmitter = new vscode.EventEmitter<void>();
     onDidChangeTreeData = this.onDidChangeTreeDataEmitter.event;
 
     private instance: CollaborationInstance | undefined;
@@ -13,36 +13,45 @@ export class CollaborationStatusViewDataProvider implements vscode.TreeDataProvi
     onConnection(instance: CollaborationInstance) {
         this.instance = instance;
         instance.onDidUsersChange(() => {
-            this.onDidChangeTreeDataEmitter.fire(undefined);
+            this.onDidChangeTreeDataEmitter.fire();
         });
         instance.onDidDispose(() => {
             this.instance = undefined;
-            this.onDidChangeTreeDataEmitter.fire(undefined);
+            this.onDidChangeTreeDataEmitter.fire();
         });
-        this.onDidChangeTreeDataEmitter.fire(undefined);
+        this.onDidChangeTreeDataEmitter.fire();
     }
 
-    async getTreeItem(element: DisposablePeer): Promise<vscode.TreeItem> {
+    async getTreeItem(peer: PeerWithColor): Promise<vscode.TreeItem> {
         const self = await this.instance?.ownUserData;
-        const treeItem = new vscode.TreeItem(element.peer.id === self?.id ? `${element.peer.name} (you)` : element.peer.name);
-        treeItem.id = element.peer.id;
+        const treeItem = new vscode.TreeItem(peer.name);
+        const tags: string[] = [];
+        if (peer.id === self?.id) {
+            tags.push('You');
+        }
+        if (peer.host) {
+            tags.push('Host');
+        }
+        treeItem.description = tags.length ? ('(' + tags.join(' • ') + ')') : undefined;
+        treeItem.id = peer.id;
         treeItem.contextValue = 'self';
-        if (self?.id !== element.peer.id) {
-            treeItem.iconPath = new vscode.ThemeIcon('circle-filled', element.decoration.getThemeColor());
-            treeItem.contextValue = this.instance?.following === treeItem.id ? 'followedPeer' : 'peer';
+        if (self?.id !== peer.id) {
+            const themeColor = typeof peer.color === 'string' ? new vscode.ThemeColor(peer.color) : undefined;
+            treeItem.iconPath = new vscode.ThemeIcon('circle-filled', themeColor);
+            treeItem.contextValue = this.instance?.following === peer.id ? 'followedPeer' : 'peer';
         }
         return treeItem;
     }
 
-    getChildren(element?: DisposablePeer): vscode.ProviderResult<DisposablePeer[]> {
+    getChildren(element?: PeerWithColor): vscode.ProviderResult<PeerWithColor[]> {
         if (!element && this.instance) {
-            return this.instance.connectedUsers
+            return this.instance.connectedUsers;
         }
         return []
     }
 
     update() {
-        this.onDidChangeTreeDataEmitter.fire(undefined);
+        this.onDidChangeTreeDataEmitter.fire();
     }
 
 }

--- a/packages/open-collaboration-vscode/src/commands.ts
+++ b/packages/open-collaboration-vscode/src/commands.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { inject, injectable } from "inversify";
 import { FollowService } from './follow-service';
-import { CollaborationInstance, DisposablePeer } from './collaboration-instance';
+import { CollaborationInstance, PeerWithColor } from './collaboration-instance';
 import { ExtensionContext } from './inversify';
 import { CollaborationConnectionProvider, OCT_USER_TOKEN } from './collaboration-connection-provider';
 import { showQuickPick } from './utils/quick-pick';
@@ -34,7 +34,7 @@ export class Commands {
 
     initialize(): void {
         this.context.subscriptions.push(
-            vscode.commands.registerCommand('oct.followPeer', (peer?: DisposablePeer) => this.followService.followPeer(peer)),
+            vscode.commands.registerCommand('oct.followPeer', (peer?: PeerWithColor) => this.followService.followPeer(peer?.id)),
             vscode.commands.registerCommand('oct.stopFollowPeer', () => this.followService.unfollowPeer()),
             vscode.commands.registerCommand('oct.enter', async () => {
                 const connectionProvider = await this.connectionProvider.createConnection();

--- a/packages/open-collaboration-vscode/src/follow-service.ts
+++ b/packages/open-collaboration-vscode/src/follow-service.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { inject, injectable } from "inversify";
-import { CollaborationInstance, DisposablePeer } from "./collaboration-instance";
+import { CollaborationInstance } from "./collaboration-instance";
 import { showQuickPick } from './utils/quick-pick';
 import { CollaborationStatusViewDataProvider } from './collaboration-status-view';
 
@@ -10,23 +10,23 @@ export class FollowService {
     @inject(CollaborationStatusViewDataProvider)
     private viewDataProvider: CollaborationStatusViewDataProvider;
 
-    async followPeer(peer?: DisposablePeer): Promise<void> {
+    async followPeer(peer?: string): Promise<void> {
         if (!CollaborationInstance.Current) {
             return;
         }
 
         if (!peer) {
             const quickPick = vscode.window.createQuickPick();
-            const users = CollaborationInstance.Current.connectedUsers
-            quickPick.items = users.map(user => ({ label: user.peer.name, detail: user.peer.id }));
-            peer = users[(await showQuickPick(quickPick))];
+            const users = await CollaborationInstance.Current.connectedUsers;
+            quickPick.items = users.map(user => ({ label: user.name, detail: user.id }));
+            peer = users[(await showQuickPick(quickPick))]?.id;
         }
 
         if (!peer) {
             return;
         }
 
-        CollaborationInstance.Current.followUser(peer.peer.id);
+        CollaborationInstance.Current.followUser(peer);
         this.viewDataProvider.update();
     }
 

--- a/packages/open-collaboration-vscode/src/utils/package.ts
+++ b/packages/open-collaboration-vscode/src/utils/package.ts
@@ -1,0 +1,5 @@
+export const packageJson = require('../../package.json');
+export const packageVersion: string = packageJson.version;
+export const userColors: string[] = packageJson.contributes.colors
+    .map((color: any) => color.id)
+    .filter((id: string) => id.startsWith('oct.user.'));


### PR DESCRIPTION
Closes https://github.com/TypeFox/open-collaboration-tools/issues/36

This fixes the issue of missing users in the session view. The main issue was that we didn't call `onDidUsersChange` in our collaboration instance on a few of the peer related requests. Especially important is the `peer/init` notification: Upon joining a room their view was empty - only after another user joins would their view get populated. Now the view is populated instantly.