### PR TITLE
[VS Code] Fix URI comparison on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4327,9 +4327,9 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
         "braces": "^3.0.3",
@@ -7508,7 +7508,7 @@
     },
     "packages/open-collaboration-vscode": {
       "name": "open-collaboration-tools",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "async-mutex": "^0.5.0",

--- a/packages/open-collaboration-vscode/package.json
+++ b/packages/open-collaboration-vscode/package.json
@@ -50,6 +50,16 @@
     }
   },
   "contributes": {
+    "resourceLabelFormatters": [
+      {
+        "scheme": "oct",
+        "formatting": {
+          "label": "${path}",
+          "separator": "/",
+          "workspaceSuffix": "Open Collaboration Tools"
+        }
+      }
+    ],
     "configuration": {
       "title": "Open Collaboration Tools",
       "properties": {

--- a/packages/open-collaboration-vscode/package.json
+++ b/packages/open-collaboration-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "open-collaboration-tools",
   "displayName": "Open Collaboration Tools",
   "description": "Connect with others and live-share your code in real-time collaboration sessions",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "publisher": "typefox",
   "categories": [
     "Other"

--- a/packages/open-collaboration-vscode/src/utils/uri.ts
+++ b/packages/open-collaboration-vscode/src/utils/uri.ts
@@ -18,10 +18,10 @@ export namespace CollaborationUri {
         if (!uri) {
             return undefined;
         }
-        const path = uri.path.toString();
+        const path = uri.toString();
         const roots = (vscode.workspace.workspaceFolders ?? []);
         for (const root of roots) {
-            const rootUri = root.uri.path + '/';
+            const rootUri = root.uri.toString() + '/';
             if (path.startsWith(rootUri)) {
                 return root.name + '/' + path.substring(rootUri.length);
             }


### PR DESCRIPTION
Sometimes, when opening a workspace, the workspace gets opened with an upper case drive letter. However, the file URIs are still passed from VS Code with a lower case drive letter. This leads to issues when running the `getProtocolPath` function, as the `startsWith` function returns false when the casing differs.

By using `vscode.Uri#toString()`, we normalize the paths to ensure that we get the correct path.

Updates the VS Code extension to 0.2.2