### PR TITLE
Added option for a redirect request for oauth login

### DIFF
--- a/packages/open-collaboration-server/README.md
+++ b/packages/open-collaboration-server/README.md
@@ -19,11 +19,12 @@ Environment variables
 | Variable | Description |
 |--------------------|---|
 | OCT_SERVER_OWNER          | Name of the server owner. E.g. the name of the company that hosts the server |
-| OCT_JWT_PRIVATE_KEY           | The private key for encoding the JWT's used for authenticating users  |
+| OCT_JWT_PRIVATE_KEY       | The private key for encoding the JWT's used for authenticating users  |
 | OCT_LOGIN_PAGE_URL        | Url of the login page. Defaults to /login.html?token={token}  |
 | OCT_LOGIN_SUCCESS_URL     | Url of the login success page. Defaults a simple "Login Successful. You can close this page" text  |
 | OCT_BASE_URL              | Base URL of the server is reachable under. Used for oauth redirects |
 | OCT_ACTIVATE_SIMPLE_LOGIN | Activates the simple login handler to alow unverified authentication just with username and optionally email |
 | OCT_OAUTH_{Provider Name}_CLIENTID | Sets the client id for the specified OAuth provider |
 | OCT_OAUTH_{Provider Name}_CLIENTSECRET | Sets the client secret for the specified OAuth provider |
+| OCT_REDIRECT_URI_WHITELIST | A comma seperated list to allow specific URLs with the `redirect` query parameter when authenticating with an OAuth provider  |
 

--- a/packages/open-collaboration-server/README.md
+++ b/packages/open-collaboration-server/README.md
@@ -26,5 +26,5 @@ Environment variables
 | OCT_ACTIVATE_SIMPLE_LOGIN | Activates the simple login handler to alow unverified authentication just with username and optionally email |
 | OCT_OAUTH_{Provider Name}_CLIENTID | Sets the client id for the specified OAuth provider |
 | OCT_OAUTH_{Provider Name}_CLIENTSECRET | Sets the client secret for the specified OAuth provider |
-| OCT_REDIRECT_URI_WHITELIST | A comma seperated list to allow specific URLs with the `redirect` query parameter when authenticating with an OAuth provider  |
+| OCT_REDIRECT_URL_WHITELIST | A comma seperated list to allow usage of the specified URLs with the `redirect` query parameter when authenticating with a provider which redirects back after success |
 

--- a/packages/open-collaboration-server/src/auth-endpoints/oauth-endpoint.ts
+++ b/packages/open-collaboration-server/src/auth-endpoints/oauth-endpoint.ts
@@ -91,7 +91,7 @@ export abstract class OAuthEndpoint implements AuthEndpoint {
                     if(!redirectUriWhitelist?.includes(redirectRequest)) {
                         this.logger.error(`Redirect URI ${redirectRequest} not in whitelist`);
                         res.status(400);
-                        res.send('Error: Redirect URI not in whitelist');
+                        res.send('Error: Redirect URL not in whitelist');
                     } else {
                         res.redirect(redirectRequest);
                     }

--- a/packages/open-collaboration-server/src/auth-endpoints/oauth-endpoint.ts
+++ b/packages/open-collaboration-server/src/auth-endpoints/oauth-endpoint.ts
@@ -60,7 +60,7 @@ export abstract class OAuthEndpoint implements AuthEndpoint {
         });
 
         const loginSuccessURL = this.configuration.getValue('oct-login-success-url');
-        const redirectUriWhitelist = this.configuration.getValue('oct-redirect-uri-whitelist')?.split(',');
+        const redirectUriWhitelist = this.configuration.getValue('oct-redirect-url-whitelist')?.split(',');
         app.get(this.redirectPath, async (req, res) => {
             const token = (req.query.state as string);
             if (!token) {


### PR DESCRIPTION
When logging in via a oauth provider you can now add `redirect=someurl` in the url query to request to be redirected to some specific site instead of the default configured login success redirect url. 
The redirect url has to be in the comma seperated list of whitlisted urls set through `oct-redirect-uri-whitelist`

**How to test**
1. create a github oauth provider
2. configure the oct server with the provider
3. create the  `OCT_REDIRECT_URI_WHITELIST` env-variable and add your uri
4. start the server and open `http://localhost:8100/api/login/github?token=sometoken&redirect=yourRedirectUri`
5. after login is successfull you should be redirected to the given uri.
6. if the uri is not in the whitelist you should get an error 