### PR TITLE
[VSCode] Skip path URI encoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8913,7 +8913,7 @@
     },
     "packages/open-collaboration-vscode": {
       "name": "open-collaboration-tools",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "async-mutex": "^0.5.0",

--- a/packages/open-collaboration-vscode/package.json
+++ b/packages/open-collaboration-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "open-collaboration-tools",
   "displayName": "Open Collaboration Tools",
   "description": "Connect with others and live-share your code in real-time collaboration sessions",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "publisher": "typefox",
   "categories": [
     "Other"

--- a/packages/open-collaboration-vscode/src/utils/uri.ts
+++ b/packages/open-collaboration-vscode/src/utils/uri.ts
@@ -18,10 +18,10 @@ export namespace CollaborationUri {
         if (!uri) {
             return undefined;
         }
-        const path = uri.toString();
+        const path = uri.toString(true);
         const roots = (vscode.workspace.workspaceFolders ?? []);
         for (const root of roots) {
-            const rootUri = root.uri.toString() + '/';
+            const rootUri = root.uri.toString(true) + '/';
             if (path.startsWith(rootUri)) {
                 return root.name + '/' + path.substring(rootUri.length);
             }


### PR DESCRIPTION
Closes https://github.com/TypeFox/open-collaboration-tools/issues/69

Currently, unicode symbols in files get URL encoded when using `toString`. Since these files aren't supposed to be used in URLs but as file system identifiers, we have to skip the encoding.

Updates the version for a new patch release of the VS Code extension.